### PR TITLE
change config form .env to be optional

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ var config Config = Config{
 
 // Load config from .env and environment variable, only need to call once in one execution.
 func (c *Config) Load() *Config {
-	if err := cfg.From(".env").FromEnv().To(c); err != nil {
+	if err := cfg.FromOptional(".env").FromEnv().To(c); err != nil {
 		panic(err)
 	}
 	return c


### PR DESCRIPTION
The cloud run CD failed since .env file does't exist, changing cfg.From to cfg.FromOptional fix this problem.